### PR TITLE
🔒 [security fix] Broken Access Control on Routine Creation and Category Management

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -24,12 +24,14 @@ Route::prefix('v1')->middleware('auth:sanctum')->group(function () {
     Route::get('/user', [AuthController::class, 'user']);
 
     // Trainer routes
-    Route::get('/trainer/students', [\App\Http\Controllers\Api\V1\Trainer\StudentController::class, 'index']);
-    Route::get('/trainer/stats', [\App\Http\Controllers\Api\V1\Trainer\StudentController::class, 'stats']);
-    Route::get('/trainer/routines', [\App\Http\Controllers\Api\V1\Trainer\RoutineController::class, 'index']);
-    Route::post('/trainer/routines', [\App\Http\Controllers\Api\V1\Trainer\RoutineController::class, 'store']);
-    Route::post('/trainer/routines/assign', [\App\Http\Controllers\Api\V1\Trainer\RoutineController::class, 'assign']);
-    Route::get('/trainer/exercises', [\App\Http\Controllers\Api\V1\Trainer\RoutineController::class, 'exercises']);
+    Route::middleware('role:profesor|super-admin')->group(function () {
+        Route::get('/trainer/students', [\App\Http\Controllers\Api\V1\Trainer\StudentController::class, 'index']);
+        Route::get('/trainer/stats', [\App\Http\Controllers\Api\V1\Trainer\StudentController::class, 'stats']);
+        Route::get('/trainer/routines', [\App\Http\Controllers\Api\V1\Trainer\RoutineController::class, 'index']);
+        Route::post('/trainer/routines', [\App\Http\Controllers\Api\V1\Trainer\RoutineController::class, 'store']);
+        Route::post('/trainer/routines/assign', [\App\Http\Controllers\Api\V1\Trainer\RoutineController::class, 'assign']);
+        Route::get('/trainer/exercises', [\App\Http\Controllers\Api\V1\Trainer\RoutineController::class, 'exercises']);
+    });
 
     // Student dashboard
     Route::middleware('role:alumno|student')->group(function () {
@@ -42,7 +44,14 @@ Route::prefix('v1')->middleware('auth:sanctum')->group(function () {
     });
 
     // Categories
-    Route::apiResource('categories', CategoryController::class);
+    Route::get('/categories', [CategoryController::class, 'index']);
+    Route::get('/categories/{category}', [CategoryController::class, 'show']);
+    Route::middleware('role:super-admin')->group(function () {
+        Route::post('/categories', [CategoryController::class, 'store']);
+        Route::put('/categories/{category}', [CategoryController::class, 'update']);
+        Route::patch('/categories/{category}', [CategoryController::class, 'update']);
+        Route::delete('/categories/{category}', [CategoryController::class, 'destroy']);
+    });
 
     // Admin routes (super-admin only)
     Route::middleware('role:super-admin')->group(function () {

--- a/tests/Feature/Security/AccessControlTest.php
+++ b/tests/Feature/Security/AccessControlTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature\Security;
+
+use App\Models\User;
+use App\Models\Category;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Spatie\Permission\Models\Role;
+
+class AccessControlTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create roles
+        Role::create(['name' => 'student', 'guard_name' => 'web']);
+        Role::create(['name' => 'profesor', 'guard_name' => 'web']);
+        Role::create(['name' => 'super-admin', 'guard_name' => 'web']);
+    }
+
+    /**
+     * Test that a student cannot access trainer routes
+     */
+    public function test_student_cannot_access_trainer_routes()
+    {
+        $student = User::factory()->create();
+        $student->assignRole('student');
+
+        $response = $this->actingAs($student, 'sanctum')->getJson('/api/v1/trainer/students');
+
+        $response->assertStatus(403);
+    }
+
+    /**
+     * Test that a student cannot create routines
+     */
+    public function test_student_cannot_create_routines()
+    {
+        $student = User::factory()->create();
+        $student->assignRole('student');
+
+        $response = $this->actingAs($student, 'sanctum')->postJson('/api/v1/trainer/routines', [
+            'name' => 'Unauthorized Routine',
+            'difficulty' => 'Básico',
+            'exercises' => []
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    /**
+     * Test that a student cannot create categories
+     */
+    public function test_student_cannot_create_categories()
+    {
+        $student = User::factory()->create();
+        $student->assignRole('student');
+
+        $response = $this->actingAs($student, 'sanctum')->postJson('/api/v1/categories', [
+            'name' => 'Unauthorized Category',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    /**
+     * Test that a trainer can access trainer routes
+     */
+    public function test_trainer_can_access_trainer_routes()
+    {
+        $trainer = User::factory()->create();
+        $trainer->assignRole('profesor');
+
+        $response = $this->actingAs($trainer, 'sanctum')->getJson('/api/v1/trainer/students');
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
### 🔒 Broken Access Control Fix

#### 🎯 What:
Fixed a security vulnerability where trainer-specific routes and category management endpoints were exposed to all authenticated users, regardless of their role.

#### ⚠️ Risk:
Unauthorized users (e.g., students) could:
- Create, list, and assign routines.
- View stats and lists of all students assigned to any trainer.
- Create, update, or delete categories.

#### 🛡️ Solution:
- Applied `role:profesor|super-admin` middleware to all `/trainer/*` API routes.
- Applied `role:super-admin` middleware to sensitive category management routes (`store`, `update`, `destroy`).
- Created `tests/Feature/Security/AccessControlTest.php` to ensure correct role-based access to these endpoints.


---
*PR created automatically by Jules for task [14464637317797581259](https://jules.google.com/task/14464637317797581259) started by @cartes*