### PR TITLE
🧹 fix: order recent students by assignment date using orderByPivot

### DIFF
--- a/app/Http/Controllers/Api/V1/Trainer/StudentController.php
+++ b/app/Http/Controllers/Api/V1/Trainer/StudentController.php
@@ -30,7 +30,7 @@ class StudentController extends Controller
         $totalStudents = $user->students()->count();
         $totalRoutines = $user->routines()->count();
         $totalExercises = Exercise::count();
-        $recentStudents = $user->students()->latest()->take(5)->get();
+        $recentStudents = $user->students()->orderByPivot('created_at', 'desc')->take(5)->get();
         $recentRoutines = $user->routines()->with('exercises')->latest()->take(5)->get();
         $assignedRoutinesCount = $user->routines()
             ->has('students')

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -66,7 +66,8 @@ class User extends Authenticatable
      */
     public function students(): BelongsToMany
     {
-        return $this->belongsToMany(User::class, 'professor_student', 'professor_id', 'student_id');
+        return $this->belongsToMany(User::class, 'professor_student', 'professor_id', 'student_id')
+            ->withTimestamps();
     }
 
 


### PR DESCRIPTION
The "recent students" list in the trainer dashboard was incorrectly ordered by the date the student users were created, not when they were assigned to the trainer. 

Changes:
- Added `withTimestamps()` to the `students()` relationship in the `User` model to enable pivot table timestamp management.
- Replaced `latest()` with `orderByPivot('created_at', 'desc')` in `StudentController@stats` to ensure students are sorted by their assignment date.
- Verified syntax using `php -l`.
- Verified logic via code review.

---
*PR created automatically by Jules for task [16893579477832410723](https://jules.google.com/task/16893579477832410723) started by @cartes*