### PR TITLE
⚡ Optimize Moderator Dashboard count queries

### DIFF
--- a/app/Http/Controllers/Api/V1/Moderator/DashboardController.php
+++ b/app/Http/Controllers/Api/V1/Moderator/DashboardController.php
@@ -15,9 +15,16 @@ class DashboardController extends Controller
     public function index(Request $request)
     {
         $totalUsers = User::count();
-        $totalProfesores = User::role('profesor')->count();
-        $totalAlumnos = User::role('alumno')->count();
-        $totalModerators = User::role('moderador')->count();
+
+        // Optimize: Get all role counts in a single query
+        $roleCounts = Role::whereIn('name', ['profesor', 'alumno', 'moderador'])
+            ->withCount('users')
+            ->get()
+            ->pluck('users_count', 'name');
+
+        $totalProfesores = $roleCounts['profesor'] ?? 0;
+        $totalAlumnos = $roleCounts['alumno'] ?? 0;
+        $totalModerators = $roleCounts['moderador'] ?? 0;
 
         // Recent users (last 10 registered)
         $recentUsers = User::with('roles')


### PR DESCRIPTION
💡 **What:** Replaced four sequential database count queries in the Moderator Dashboard with two optimized queries.

🎯 **Why:** The previous implementation executed four separate `SELECT COUNT(*)` queries (one for total users and three for specific roles), causing unnecessary database roundtrips and overhead.

📊 **Measured Improvement:** By using `Role::whereIn(...)->withCount('users')`, the number of queries is reduced from 4 to 2. This results in a 50% reduction in database roundtrips for this specific dashboard view, improving response time and reducing database load. Note: A formal benchmark was not possible due to environment limitations (missing vendor dependencies), but the improvement is architecturally significant.

---
*PR created automatically by Jules for task [5534393041761928036](https://jules.google.com/task/5534393041761928036) started by @cartes*