### PR TITLE
Add Unit Tests for User and Category Models

### DIFF
--- a/tests/Unit/Models/CategoryTest.php
+++ b/tests/Unit/Models/CategoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Category;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CategoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_category_can_be_created(): void
+    {
+        $category = Category::create([
+            'name' => 'Fitness',
+            'slug' => 'fitness',
+            'order' => 1,
+        ]);
+
+        $this->assertDatabaseHas('categories', [
+            'slug' => 'fitness',
+        ]);
+        $this->assertEquals('Fitness', $category->name);
+    }
+
+    public function test_category_hierarchy(): void
+    {
+        $parent = Category::create([
+            'name' => 'Workouts',
+            'slug' => 'workouts',
+            'order' => 1,
+        ]);
+
+        $child = Category::create([
+            'name' => 'Cardio',
+            'slug' => 'cardio',
+            'order' => 1,
+            'parent_id' => $parent->id,
+        ]);
+
+        // Refresh models
+        $parent->refresh();
+        $child->refresh();
+
+        // Assert parent relationship
+        $this->assertEquals($parent->id, $child->parent->id);
+        $this->assertEquals('Workouts', $child->parent->name);
+
+        // Assert children relationship
+        $this->assertTrue($parent->children->contains($child));
+        $this->assertEquals(1, $parent->children->count());
+
+        // Assert subcategories alias
+        $this->assertTrue($parent->subcategories->contains($child));
+    }
+}

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Routine;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_be_created(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+        ]);
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'test@example.com',
+        ]);
+        $this->assertEquals('Test User', $user->name);
+    }
+
+    public function test_user_can_have_students_and_trainers(): void
+    {
+        $professor = User::factory()->create();
+        $student = User::factory()->create();
+
+        // Attach student to professor via 'students' relationship
+        $professor->students()->attach($student->id);
+
+        // Refresh models to load relationships
+        $professor->refresh();
+        $student->refresh();
+
+        // Assert professor has this student
+        $this->assertTrue($professor->students->contains($student));
+
+        // Assert student has this professor (via trainers relationship)
+        $this->assertTrue($student->trainers->contains($professor));
+    }
+
+    public function test_user_can_have_assigned_routines(): void
+    {
+        $student = User::factory()->create();
+        $trainer = User::factory()->create();
+
+        // Create a routine manually since RoutineFactory might not exist or be configured
+        $routine = Routine::create([
+            'name' => 'Test Routine',
+            'description' => 'A test routine description',
+            'difficulty' => 'beginner',
+            'trainer_id' => $trainer->id,
+        ]);
+
+        // Assign routine to student
+        // The pivot table 'user_routine' likely needs 'assigned_by' field based on migration
+        $student->assignedRoutines()->attach($routine->id, [
+            'assigned_by' => $trainer->id,
+            'is_active' => true
+        ]);
+
+        $student->refresh();
+
+        $this->assertTrue($student->assignedRoutines->contains($routine));
+        $this->assertEquals($trainer->id, $student->assignedRoutines->first()->pivot->assigned_by);
+    }
+}


### PR DESCRIPTION
Added unit tests for the core `User` and `Category` models to ensure data integrity and relationship logic.

**UserTest:**
- Verifies user creation via factory.
- Tests the `students()` (Professor -> Student) and `trainers()` (Student -> Professor) relationships, which use the `professor_student` pivot table.
- Tests the `assignedRoutines()` relationship, manually creating a routine (due to missing factory) and attaching it to a student via `user_routine`.

**CategoryTest:**
- Verifies category creation.
- Tests the hierarchical structure: creating a parent and a child, asserting the `parent` and `children` relationships work correctly.
- Verifies the `subcategories` alias.

**Note:** The tests are written using standard Laravel testing traits (`RefreshDatabase`). They cannot be executed in the current environment due to missing vendor dependencies, but are ready to run once `composer install` is performed.

---
*PR created automatically by Jules for task [13203470727197861348](https://jules.google.com/task/13203470727197861348) started by @cartes*